### PR TITLE
Fix: Correct Docusaurus configuration for GitHub Pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,8 +40,8 @@ const config = {
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  organizationName: 'ilulale', // Usually your GitHub org/user name.
+  projectName: 'hackthenotes', // Usually your repo name.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -64,7 +64,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/ilulale/hackthenotes/tree/main/',
           
         },
         theme: {
@@ -95,7 +95,7 @@ const config = {
             label: 'Knowledge Base',
           },
           {
-            href: 'https://github.com/facebook/docusaurus',
+            href: 'https://github.com/ilulale/hackthenotes',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
Updated docusaurus.config.js to correctly configure the site for deployment on GitHub Pages under a subdirectory. This includes setting the correct 'organizationName', 'projectName', 'editUrl', and navbar GitHub link.