### PR TITLE
Fix: Use baseUrl in TopicList component

### DIFF
--- a/src/components/TopicList.js
+++ b/src/components/TopicList.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 function DocItem({doc}) {
   return (
     <li>
-      <a href={doc.path}>{doc.title}</a>
+      <a href={useBaseUrl(doc.path)}>{doc.title}</a>
     </li>
   );
 }


### PR DESCRIPTION
Updates the TopicList component to use the `useBaseUrl` hook when generating links to documents. This ensures that the links work correctly when you deploy the site to a subdirectory on GitHub Pages.