### PR TITLE
Refactor: Rename Bug Bounty KB to HackTheNotes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,7 +23,7 @@ const docItems = fs.readdirSync(docsPath).map((item) => {
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'hackthenotes',
+  title: 'HackTheNotes',
   tagline: 'Your personal knowledge base for bug bounty hunting.',
   favicon: 'img/favicon.ico',
 
@@ -63,8 +63,6 @@ const config = {
           sidebarPath: './sidebars.js',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/ilulale/hackthenotes/tree/main/',
           
         },
         theme: {
@@ -82,9 +80,9 @@ const config = {
       // Replace with your project's social card
       image: 'img/docusaurus-social-card.jpg',
       navbar: {
-        title: 'hackthenotes',
+        title: 'HackTheNotes',
         logo: {
-          alt: 'hackthenotes Logo',
+          alt: 'HackTheNotes Logo',
           src: 'img/logo.svg',
         },
         items: [
@@ -105,7 +103,7 @@ const config = {
       footer: {
         style: 'dark',
         links: [],
-        copyright: `Copyright © ${new Date().getFullYear()} Bug Bounty KB.`,
+        copyright: `Copyright © ${new Date().getFullYear()} HackTheNotes.`,
       },
       prism: {
         theme: prismThemes.github,

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: Knowledge Base Index
+title: HackTheNotes Index
 ---
 
 import TopicList from '@site/src/components/TopicList';
 
-# Knowledge Base Index
+# HackTheNotes Index
 
-Welcome to the knowledge base. Here you can find information on various topics.
+Welcome to HackTheNotes. Here you can find information on various topics.
 
 <TopicList />


### PR DESCRIPTION
This commit renames the project from "Bug Bounty KB" to "HackTheNotes" across the codebase.

Changes include:
- Updating the site title, navbar title, and logo alt text in `docusaurus.config.js`.
- Updating the copyright notice in the footer.
- Removing the "Edit this page" link from the docs.
- Updating the main page title and welcome message in `src/pages/index.mdx`.